### PR TITLE
SG-602 Data is deleted from the bucket when the bucket is deleted

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -923,7 +923,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 				diffBucket := strings.TrimPrefix(d.SecondURL, dstClt.GetURL().String())
 				if isRemove {
 					aliasedDstBucket := path.Join(dstURL, diffBucket)
-					err := deleteBucket(ctx, aliasedDstBucket, false)
+					err := deleteBucket(ctx, aliasedDstBucket, false, false)
 					mj.status.fatalIf(err, "Failed to start mirroring.")
 				}
 				continue

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/minio/minio-go/v7"
 	"path"
 	"path/filepath"
 	"strings"
@@ -29,6 +28,7 @@ import (
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
 	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/pkg/console"
 )
 


### PR DESCRIPTION
## Description

Added new flag (`--keep`) which allows to keep objects and object metadata when deleting bucket

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
