### PR TITLE
SG-621: Update MinIO mc to support new ListGroups interface

### DIFF
--- a/cmd/admin-group-add.go
+++ b/cmd/admin-group-add.go
@@ -72,11 +72,17 @@ type groupMessage struct {
 func (u groupMessage) String() string {
 	switch u.op {
 	case "list":
-		var s []string
-		for _, g := range u.Groups {
-			s = append(s, console.Colorize("GroupMessage", g))
-		}
-		return strings.Join(s, "\n")
+		nameFieldMaxLen := 20
+		statusFieldMaxLen := 9
+		policyFieldMaxLen := 20
+		membersFieldMaxLen := 40
+
+		return newPrettyTable(" ",
+			Field{"GroupName", nameFieldMaxLen},
+			Field{"GroupStatus", statusFieldMaxLen},
+			Field{"GroupPolicy", policyFieldMaxLen},
+			Field{"GroupMembers", membersFieldMaxLen},
+		).buildRow(u.GroupName, u.GroupStatus, u.GroupPolicy, strings.Join(u.Members, ","))
 	case "disable":
 		return console.Colorize("GroupMessage", "Disabled group `"+u.GroupName+"` successfully.")
 	case "enable":

--- a/cmd/admin-group-list.go
+++ b/cmd/admin-group-list.go
@@ -58,6 +58,10 @@ func mainAdminGroupList(ctx *cli.Context) error {
 	checkAdminGroupListSyntax(ctx)
 
 	console.SetColor("GroupMessage", color.New(color.FgGreen))
+	console.SetColor("GroupName", color.New(color.FgBlue))
+	console.SetColor("GroupMembers", color.New(color.FgRed))
+	console.SetColor("GroupPolicy", color.New(color.FgYellow))
+	console.SetColor("GroupStatus", color.New(color.FgCyan))
 
 	// Get the alias parameter from cli
 	args := ctx.Args()
@@ -70,10 +74,15 @@ func mainAdminGroupList(ctx *cli.Context) error {
 	gs, e := client.ListGroups(globalContext)
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to list groups")
 
-	printMsg(groupMessage{
-		op:     "list",
-		Groups: gs,
-	})
+	for _, groupDesc := range gs {
+		printMsg(groupMessage{
+			op:          "list",
+			GroupName:   groupDesc.Name,
+			Members:     groupDesc.Members,
+			GroupStatus: groupDesc.Status,
+			GroupPolicy: groupDesc.Policy,
+		})
+	}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -121,4 +121,4 @@ replace github.com/minio/pkg => github.com/panasasinc/minio-pkg v1.5.5-0.2023033
 
 replace github.com/minio/minio-go/v7 v7.0.41 => github.com/panasasinc/minio-go/v7 v7.0.0-20221206164009-5985ee51debf
 
-replace github.com/minio/madmin-go => github.com/panasasinc/madmin-go v0.0.0-20230331061341-8fdaf3295741
+replace github.com/minio/madmin-go => github.com/panasasinc/madmin-go v1.6.7-0.20230524085333-532553a0f7e2

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/panasasinc/madmin-go v0.0.0-20230331061341-8fdaf3295741 h1:pg5zCBu0vhE80JNDuJ2Nzy8zPJEhCMCOlEhN1f+n3q8=
-github.com/panasasinc/madmin-go v0.0.0-20230331061341-8fdaf3295741/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
+github.com/panasasinc/madmin-go v1.6.7-0.20230524085333-532553a0f7e2 h1:mnuvPqRwcL6jtvTY3zwBo0Y5X774OWxbn7pAvWjcCaY=
+github.com/panasasinc/madmin-go v1.6.7-0.20230524085333-532553a0f7e2/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
 github.com/panasasinc/minio-go/v7 v7.0.0-20221206164009-5985ee51debf h1:H1tBUSBWU7Q4O4dpbJAaPKKu2lmpLEsFerl4XJ4xut0=
 github.com/panasasinc/minio-go/v7 v7.0.0-20221206164009-5985ee51debf/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/panasasinc/minio-pkg v1.5.5-0.20230331124037-2837fe391278 h1:Ewqq6jAMZ7sUhl7iMd3cFBf4/KSJzW4+pXs8Cw9ZXpY=


### PR DESCRIPTION
## Description
Update MinIO mc ListGroups() handler to print table of group info or return JSON objects for each group.

## Motivation and Context
This change should significantly speedup S3 group listing via UI.

## How to test this PR?
Tested manually with updated madmin-go and minio-mc packages:

```
yauhenm@pavm31-9:.../git/minio-mc$ ./mc --json admin group list mypanfs
{
 "status": "success",
 "groupName": "admins",
 "members": [
  "test4"
 ],
 "groupStatus": "enabled",
 "groupPolicy": "readwrite"
}
{
 "status": "success",
 "groupName": "users",
 "members": [
  "test1",
  "test3"
 ],
 "groupStatus": "enabled",
 "groupPolicy": "readonly"
}
yauhenm@pavm31-9:.../git/minio-mc$ ./mc admin group list mypanfs
admins               enabled   readwrite            test4                                   
users                enabled   readonly             test1,test3  
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
